### PR TITLE
[optimization] move Sender/Receiver data

### DIFF
--- a/benches/criterion_benchmarks.rs
+++ b/benches/criterion_benchmarks.rs
@@ -51,6 +51,7 @@ impl<const SIZE: usize> Default for FilledVec<SIZE> {
     }
 }
 
+#[allow(clippy::len_without_is_empty)]
 pub trait Length {
     fn len(&self) -> usize;
 }
@@ -349,12 +350,12 @@ async fn async_select_recv_buffer_0(msg_no: usize) {
     let (tx2, rx2) = bounded(0);
 
     tokio::spawn(async move {
-        for i in (0..count).into_iter().filter(|n| n % 2 == 0) {
+        for i in (0..count).filter(|n| n % 2 == 0) {
             tx1.send_async(i).await.unwrap();
         }
     });
     tokio::spawn(async move {
-        for i in (0..count).into_iter().filter(|n| n % 2 == 1) {
+        for i in (0..count).filter(|n| n % 2 == 1) {
             tx2.send_async(i).await.unwrap();
         }
     });

--- a/benchmark/src/async_channel_bench.rs
+++ b/benchmark/src/async_channel_bench.rs
@@ -126,11 +126,8 @@ where
 {
     JoinHandle::Sync(thread::spawn(move || {
         let mut received_count = 0;
-        loop {
-            match recv(&rx) {
-                Ok(_) => received_count += 1,
-                Err(_) => break,
-            }
+        while recv(&rx).is_ok() {
+            received_count += 1;
         }
         received_count
     }))
@@ -142,11 +139,8 @@ where
 {
     JoinHandle::Async(tokio::spawn(async move {
         let mut received_count = 0;
-        loop {
-            match recv_async(&rx).await {
-                Ok(_) => received_count += 1,
-                Err(_) => break,
-            }
+        while recv_async(&rx).await.is_ok() {
+            received_count += 1;
         }
         received_count
     }))

--- a/benchmark/src/bench_utils.rs
+++ b/benchmark/src/bench_utils.rs
@@ -4,6 +4,7 @@ pub struct BenchResult {
     pub throughput: usize,
 }
 
+#[allow(clippy::enum_variant_names)]
 #[derive(Debug)]
 pub enum BenchError {
     ZeroCapacityNotSupported,

--- a/benchmark/src/crossbeam_channel_bench.rs
+++ b/benchmark/src/crossbeam_channel_bench.rs
@@ -92,11 +92,8 @@ where
 {
     JoinHandle::Sync(thread::spawn(move || {
         let mut received_count = 0;
-        loop {
-            match recv(&rx) {
-                Ok(_) => received_count += 1,
-                Err(_) => break,
-            }
+        while recv(&rx).is_ok() {
+            received_count += 1;
         }
         received_count
     }))

--- a/benchmark/src/flume_bench.rs
+++ b/benchmark/src/flume_bench.rs
@@ -123,11 +123,8 @@ where
 {
     JoinHandle::Sync(thread::spawn(move || {
         let mut received_count = 0;
-        loop {
-            match recv(&rx) {
-                Ok(_) => received_count += 1,
-                Err(_) => break,
-            }
+        while recv(&rx).is_ok() {
+            received_count += 1;
         }
         received_count
     }))
@@ -139,11 +136,8 @@ where
 {
     JoinHandle::Async(tokio::spawn(async move {
         let mut received_count = 0;
-        loop {
-            match recv_async(&rx).await {
-                Ok(_) => received_count += 1,
-                Err(_) => break,
-            }
+        while recv_async(&rx).await.is_ok() {
+            received_count += 1;
         }
         received_count
     }))

--- a/benchmark/src/kanal_bench.rs
+++ b/benchmark/src/kanal_bench.rs
@@ -126,11 +126,8 @@ where
 {
     JoinHandle::Sync(thread::spawn(move || {
         let mut received_count = 0;
-        loop {
-            match recv(&rx) {
-                Ok(_) => received_count += 1,
-                Err(_) => break,
-            }
+        while recv(&rx).is_ok() {
+            received_count += 1;
         }
         received_count
     }))
@@ -143,11 +140,8 @@ where
     let rx = rx.to_async();
     JoinHandle::Async(tokio::spawn(async move {
         let mut received_count = 0;
-        loop {
-            match recv_async(&rx).await {
-                Ok(_) => received_count += 1,
-                Err(_) => break,
-            }
+        while recv_async(&rx).await.is_ok() {
+            received_count += 1;
         }
         received_count
     }))

--- a/benchmark/src/loole_bench.rs
+++ b/benchmark/src/loole_bench.rs
@@ -123,11 +123,8 @@ where
 {
     JoinHandle::Sync(thread::spawn(move || {
         let mut received_count = 0;
-        loop {
-            match recv(&rx) {
-                Ok(_) => received_count += 1,
-                Err(_) => break,
-            }
+        while recv(&rx).is_ok() {
+            received_count += 1;
         }
         received_count
     }))
@@ -139,11 +136,8 @@ where
 {
     JoinHandle::Async(tokio::spawn(async move {
         let mut received_count = 0;
-        loop {
-            match recv_async(&rx).await {
-                Ok(_) => received_count += 1,
-                Err(_) => break,
-            }
+        while recv_async(&rx).await.is_ok() {
+            received_count += 1;
         }
         received_count
     }))

--- a/benchmark/src/tokio_bench.rs
+++ b/benchmark/src/tokio_bench.rs
@@ -132,7 +132,7 @@ where
 {
     JoinHandle::Sync(thread::spawn(move || {
         let mut received_count = 0;
-        while let Some(_) = recv(&mut rx) {
+        while recv(&mut rx).is_some() {
             received_count += 1;
         }
         received_count
@@ -145,7 +145,7 @@ where
 {
     JoinHandle::Async(tokio::spawn(async move {
         let mut received_count = 0;
-        while let Some(_) = recv_async(&mut rx).await {
+        while recv_async(&mut rx).await.is_some() {
             received_count += 1;
         }
         received_count

--- a/src/mutex.rs
+++ b/src/mutex.rs
@@ -13,6 +13,6 @@ impl<T> StdMutex<T> {
 
     #[inline(always)]
     pub fn lock(&self) -> MutexGuard<T> {
-        self.0.lock().map_or_else(|e| e.into_inner(), |v| v)
+        self.0.lock().unwrap_or_else(|e| e.into_inner())
     }
 }

--- a/tests/sink.rs
+++ b/tests/sink.rs
@@ -56,9 +56,9 @@ async fn test_send_sink_multiple() {
     let (tx, rx) = unbounded();
     let mut sink = tx.into_sink();
 
-    let items = vec![1, 2, 3, 4, 5];
-    for item in items.iter() {
-        sink.send(*item).await.unwrap();
+    let items = [1, 2, 3, 4, 5];
+    for item in items {
+        sink.send(item).await.unwrap();
     }
 
     let received: Vec<i32> = rx.stream().take(5).collect().await;


### PR DESCRIPTION
[Your URLO post](https://users.rust-lang.org/t/new-release-loole-0-4-0-async-friendly-mpmc-channels-for-rust/119826?u=cod10129) has attracted a contributor!

The implementation of `Receiver` looks like this:
```rust
pub struct Receiver<T> {
    shared_state: Arc<Mutex<SharedState<T>>>,
    recv_count: Arc<AtomicUsize>,
    next_id: Arc<AtomicUsize>,
}
```
That's three different `Arc`s! I optimized the code to have `Receiver<T>` look like this:
```rust
pub struct Receiver<T> {
    inner: Arc<ReceiverInner<T>>,
}

struct ReceiverInner<T> {
    shared_state: Arc<Mutex<SharedState<T>>>,
    recv_count: AtomicUsize,
    next_id: AtomicUsize,
}
```
(The `Arc` around `shared_state` is still necessary because the `SharedState` lives outside of the group of all `Receiver`s on a channel. The `recv_count` and `next_id` fields are one per channel.)

This change is also mirrored on `Sender`/`SenderInner`.

I also took the liberty to fix various clippy warnings in the tests (try `cargo clippy --all-targets`).

### Unresolved Questions

Should the structs have an `Arc<Inner>` holding the `Arc<Mutex<SharedState>>`, or should they have both the `Arc<Inner>` and shared state next to each other?
Basically, should `Receiver` look like this instead of the change I made?
```rust
pub struct Receiver<T> {
    shared_state: Arc<Mutex<SharedState<T>>>,
    inner: Arc<ReceiverInner>,
}

struct ReceiverInner {
    recv_count: AtomicUsize,
    next_id: AtomicUsize,
}
```